### PR TITLE
enclosures: show correct values for columns

### DIFF
--- a/src/jbod/enclosure.rs
+++ b/src/jbod/enclosure.rs
@@ -120,8 +120,8 @@ pub mod BackPlane {
             enclosure_table.add_row(Row::new(vec![
                 Cell::new(&self.slot),
                 Cell::new(&self.device_path),
-                Cell::new(&self.revision),
-                Cell::new(&self.serial),
+                Cell::new(&self.vendor),
+                Cell::new(&self.model),
                 Cell::new(&self.revision),
                 Cell::new(&self.serial),
             ]));


### PR DESCRIPTION
It seems like values for columns when listing enclosures have been mixed, with the "release" version I get the following output:

```
$ ./jbod list -e
 SLOT     | DEVICE    | VENDOR | MODEL            | REVISION | SERIAL
----------+-----------+--------+------------------+----------+------------------
 2:0:24:0 | /dev/sg24 | B013   | xxx | B013     | xxx
 SLOT     | DEVICE    | VENDOR | MODEL            | REVISION | SERIAL
----------+-----------+--------+------------------+----------+------------------
 2:0:49:0 | /dev/sg49 | B013   | xxx | B013     | xxx
 SLOT     | DEVICE    | VENDOR | MODEL            | REVISION | SERIAL
----------+-----------+--------+------------------+----------+------------------
 2:0:74:0 | /dev/sg74 | B013   | xxx | B013     | xxx
 SLOT     | DEVICE    | VENDOR | MODEL            | REVISION | SERIAL
----------+-----------+--------+------------------+----------+------------------
 2:0:99:0 | /dev/sg99 | B013   | xxx | B013     | xxx
```

(Note the `VENDOR` column being the `REVISION` value and the `MODEL` being the `SERIAL`)

After this patch, the output looks like this:
```
$ ./jbod list -e
 SLOT     | DEVICE    | VENDOR  | MODEL           | REVISION | SERIAL
----------+-----------+---------+-----------------+----------+------------------
 0:0:24:0 | /dev/sg24 | GOOXIJB | 4U24SXP 36Sx12G | B013     | xxx
 SLOT     | DEVICE    | VENDOR  | MODEL           | REVISION | SERIAL
----------+-----------+---------+-----------------+----------+------------------
 0:0:49:0 | /dev/sg49 | GOOXIJB | 4U24SXP 36Sx12G | B013     | xxx
 SLOT     | DEVICE    | VENDOR  | MODEL           | REVISION | SERIAL
----------+-----------+---------+-----------------+----------+------------------
 0:0:74:0 | /dev/sg74 | GOOXIJB | 4U24SXP 36Sx12G | B013     | xxx
 SLOT     | DEVICE    | VENDOR  | MODEL           | REVISION | SERIAL
----------+-----------+---------+-----------------+----------+------------------
 0:0:99:0 | /dev/sg99 | GOOXIJB | 4U24SXP 36Sx12G | B013     | xxx
```