### PR TITLE
Add disk vendor, model and serial in "list -d"

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -87,7 +87,9 @@ fn enclosure_overview(option: &ArgMatches) -> Result<(), ()> {
                         print!(" Map: {:<10}", disk.device_map.green());
                     }
                     print!(" Slot: {:<10}", disk.slot.green());
-
+                    print!(" Vendor: {:<10}", disk.vendor.blue());
+                    print!(" Model: {:<10}", disk.model.blue());
+                    print!(" Serial: {:<10} ", disk.serial.blue());
                     let temp_conv = disk.temperature.parse::<i32>().unwrap();
                     if temp_conv > 45 && temp_conv <= 50 {
                         print!(


### PR DESCRIPTION
Reads disk info from sysfs, requires some "massaging" of the `vendor` and `model` output as it contains non printable characters that mess with the table output.

Example output:

![image](https://user-images.githubusercontent.com/218323/169242338-57a0c32a-8f2f-488b-aa10-dd75d87bbb03.png)
