### PR TITLE
fork_prometheus: fork_prometheus: rewrite without unsafe block

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ path = "src/prometheus.rs"
 clap = { version = "3.2" }
 colored = "2"
 prettytable-rs = "0.8.0"
-nix = "0.22.0"
 tokio = { version = "0.2", features = ["macros", "rt-threaded", "time"] }
 warp = "0.2"
 prometheus = {version = "0.9", features = ["process"] }


### PR DESCRIPTION
Hi found a potential way to remove an unsafe call by using Process and Child API, may also remove `nix` as a dep.