### PR TITLE
Update/clap + feature must provide one arg list + fan exclusive

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ name = "prometheus-jbod-exporter"
 path = "src/prometheus.rs"
 
 [dependencies]
-clap = { version = "2.31.2", features = ["yaml"] }
+clap = { version = "3.2" }
 colored = "2"
 prettytable-rs = "0.8.0"
 execute = "0.2.9"

--- a/src/main.rs
+++ b/src/main.rs
@@ -190,7 +190,7 @@ fn main() {
                 .about("list")
                 .arg(
                     Arg::with_name("enclosure")
-                        .short("e")
+                        .short('e')
                         .long("enclosure")
                         .multiple(false)
                         .required(false)
@@ -199,7 +199,7 @@ fn main() {
                 )
                 .arg(
                     Arg::with_name("disks")
-                        .short("d")
+                        .short('d')
                         .long("disks")
                         .multiple(false)
                         .required(false)
@@ -208,7 +208,7 @@ fn main() {
                 )
                 .arg(
                     Arg::with_name("fan")
-                        .short("f")
+                        .short('f')
                         .long("fan")
                         .multiple(false)
                         .required(false)
@@ -221,7 +221,7 @@ fn main() {
                 .about("led")
                 .arg(
                     Arg::with_name("locate")
-                        .short("l")
+                        .short('l')
                         .long("locate")
                         .required(false)
                         .multiple(true)
@@ -230,7 +230,7 @@ fn main() {
                 )
                 .arg(
                     Arg::with_name("fault")
-                        .short("f")
+                        .short('f')
                         .long("fault")
                         .required(false)
                         .multiple(true)
@@ -245,7 +245,7 @@ fn main() {
                 .about("Prometheus")
                 .arg(
                     Arg::with_name("port")
-                        .short("p")
+                        .short('p')
                         .long("port")
                         .required(false)
                         .value_name("PORT")
@@ -253,7 +253,7 @@ fn main() {
                 )
                 .arg(
                     Arg::with_name("ip-address")
-                        .short("ip")
+                        .alias("ip")
                         .long("ip-address")
                         .required(false)
                         .value_name("IPADDRESS")
@@ -264,9 +264,9 @@ fn main() {
 
     // Here it matches the menu options with its respective functions.
     match matches.subcommand() {
-        ("list", Some(m)) => enclosure_overview(m),
-        ("led", Some(m)) => DiskShelf::jbod_led_switch(m),
-        ("prometheus", Some(m)) => fork_prometheus(m),
+        Some(("list", m)) => enclosure_overview(m),
+        Some(("led", m)) => DiskShelf::jbod_led_switch(m),
+        Some(("prometheus", m)) => fork_prometheus(m),
         _ => Ok(help()),
     };
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -188,6 +188,7 @@ fn main() {
         .subcommand(
             SubCommand::with_name("list")
                 .about("list")
+                .arg_required_else_help(true)
                 .arg(
                     Arg::with_name("enclosure")
                         .short('e')

--- a/src/main.rs
+++ b/src/main.rs
@@ -214,6 +214,7 @@ fn main() {
                         .multiple(false)
                         .required(false)
                         .takes_value(false)
+                        .exclusive(false)
                         .help("List fan"),
                 ),
         )


### PR DESCRIPTION
Hello,

While testing I was surprise by just typing `jbod list` and getting nothing, I was a little bit puzzled, did this to help a little bit with command discoverability.

Why updating clap? `arg_required_else_help` was not present in 2.31.2 version.

If my reading of `enclosure_overview` function is correct: at least any of the arguments or multiple must be provided and some are exclusive  to subcomand `jbod list` no arguments do nothing.

Here what it does in case of no arguments were passed with these change:

```bash
./target/debug/jbod list
jbod-list 
list

USAGE:
    jbod list [OPTIONS]

OPTIONS:
    -d, --disks        List disks
    -e, --enclosure    List enclosure
    -f, --fan          List fan
    -h, --help         Print help information
```

Also added a way to say `--fan` is exclusive to other arguments. Before it was possible to do `-df` and fan info were not printed.

```
./target/debug/jbod list -fe 
error: The argument '--fan' cannot be used with one or more of the other specified arguments

USAGE:
    jbod list [OPTIONS]

For more information try --help
```

EDIT: edited to remove word duplication and typo + rephrasing first paragraph.