### PR TITLE
Remove unused dependancy: execute.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ path = "src/prometheus.rs"
 clap = { version = "2.31.2", features = ["yaml"] }
 colored = "2"
 prettytable-rs = "0.8.0"
-execute = "0.2.9"
 nix = "0.22.0"
 tokio = { version = "0.2", features = ["macros", "rt-threaded", "time"] }
 warp = "0.2"


### PR DESCRIPTION
If i am correct it's not used it was added on initial commit 206ba7e
doc https://docs.rs/execute