### PR TITLE
Fix formating issue in get_disk_detail.

### DIFF
--- a/src/jbod/disks.rs
+++ b/src/jbod/disks.rs
@@ -406,7 +406,7 @@ pub mod DiskShelf {
             || cmp_slot.contains("array device")
             || cmp_slot.bytes().all(|c| c.is_ascii_digit())
         {
-            let generic_device = format!("{sys_class_enclosure}{enclosure_slot}/{_slot}/{device}");
+            let generic_device = format!("{sys_class_enclosure}{enclosure_slot}/{_slot}/device");
             let physical_device =  format!("{generic_device}/scsi_generic/");
 
             if Util::path_exists(&physical_device) {


### PR DESCRIPTION
Bug was introduced in f62e271 by myself, accidentally changed from `/device` to `/{device}`. `/device` need to be verbatim in path and not interpreted as device_name.